### PR TITLE
Get unit tests passing with htmlwidgets 1.6

### DIFF
--- a/tests/testthat/test-other--BASE.R
+++ b/tests/testthat/test-other--BASE.R
@@ -89,6 +89,8 @@ test_that("Shiny Examples", {
 })
 
 test_that("Shiny Input", {
+    skip_if_not_installed("htmlwidgets", "1.6")
+
     expect_equal(as.character(canvasXpressOutput("test_id")),
-                 '<div id=\"test_id\" style=\"width:100%; height:400px; \" class=\"canvasXpress html-widget html-widget-output\"></div>')
+                 '<div class="canvasXpress html-widget html-widget-output shiny-report-size html-fill-item-overflow-hidden html-fill-item" id="test_id" style="width:100%;height:400px;"></div>')
 })


### PR DESCRIPTION
htmlwidgets 1.6 (soon to be released) adds a `fill` parameter to `htmlwidgets::shinyWidgetOutput()`, which when `TRUE` (the default), some additional CSS classes are added to the containing element.

This PR updates a unit test of `canvasXpressOutput()` to reflect the 1.6 result (and skips if 1.6 isn't available). 

I plan on submitting htmlwidgets 1.6 to CRAN within the next couple weeks. If you could please submit this patch fix to CRAN before then, it'd be much appreciated.
