### PR TITLE
Get unit tests passing with htmlwidgets 1.6.3

### DIFF
--- a/tests/testthat/test-other--BASE.R
+++ b/tests/testthat/test-other--BASE.R
@@ -90,6 +90,7 @@ test_that("Shiny Examples", {
 
 test_that("Shiny Input", {
     skip_if_not_installed("htmlwidgets", "1.6.3")
+    skip_on_cran()
 
     expect_equal(as.character(canvasXpressOutput("test_id")),
                  '<div class="canvasXpress html-widget html-widget-output shiny-report-size html-fill-item" id="test_id" style="width:100%;height:400px;"></div>')

--- a/tests/testthat/test-other--BASE.R
+++ b/tests/testthat/test-other--BASE.R
@@ -89,8 +89,8 @@ test_that("Shiny Examples", {
 
 
 test_that("Shiny Input", {
-    skip_if_not_installed("htmlwidgets", "1.6")
+    skip_if_not_installed("htmlwidgets", "1.6.3")
 
     expect_equal(as.character(canvasXpressOutput("test_id")),
-                 '<div class="canvasXpress html-widget html-widget-output shiny-report-size html-fill-item-overflow-hidden html-fill-item" id="test_id" style="width:100%;height:400px;"></div>')
+                 '<div class="canvasXpress html-widget html-widget-output shiny-report-size html-fill-item" id="test_id" style="width:100%;height:400px;"></div>')
 })


### PR DESCRIPTION
[htmlwidgets 1.6.3](https://github.com/ramnathv/htmlwidgets/pull/476) (soon to be released) removes the `html-fill-item-overflow-hidden` CSS class from HTML markup (since it's no longer needed)

This PR updates an impacted unit test to no longer include the class (and skip the test if the version of htmwidgets is outdated). Also, since `{canvasXpress}` is not in control of the relevant HTML markup, it should be skipped on CRAN (so that irrelevant changes in htmlwidgets doesn't force `{canvasXpress}` into needing a CRAN release)

I plan on submitting htmlwidgets to CRAN by the end of the week. If you could please submit this patch fix to CRAN before then, it'd be much appreciated.


